### PR TITLE
refactor: add monotonic clock

### DIFF
--- a/benchmark/dbally_benchmark/text2sql/metrics.py
+++ b/benchmark/dbally_benchmark/text2sql/metrics.py
@@ -21,9 +21,9 @@ class _ExecutionResult:
 
 def _run_query(query: str, engine: Engine) -> _ExecutionResult:
     with engine.connect() as connection:
-        start_time = time.time()
+        start_time = time.monotonic()
         rows = connection.execute(text(query)).fetchall()
-        execution_time = time.time() - start_time
+        execution_time = time.monotonic() - start_time
 
     return _ExecutionResult(
         results=[dict(row._mapping) for row in rows],  # pylint: disable=protected-access

--- a/src/dbally/collection.py
+++ b/src/dbally/collection.py
@@ -183,7 +183,7 @@ class Collection:
             IQLError: if incorrect IQL was generated `n_retries` amount of times.
             ValueError: if incorrect IQL was generated `n_retries` amount of times.
         """
-        start_time = time.time()
+        start_time = time.monotonic()
 
         event_tracker = EventTracker.initialize_with_handlers(self._event_handlers)
 
@@ -201,7 +201,7 @@ class Collection:
 
         view = self.get(selected_view)
 
-        start_time_view = time.time()
+        start_time_view = time.monotonic()
         view_result = await view.ask(
             query=question,
             llm_client=self._llm_client,
@@ -209,7 +209,7 @@ class Collection:
             n_retries=self.n_retries,
             dry_run=dry_run,
         )
-        end_time_view = time.time()
+        end_time_view = time.monotonic()
 
         textual_response = None
         if not dry_run and return_natural_response:
@@ -218,7 +218,7 @@ class Collection:
         result = ExecutionResult(
             results=view_result.results,
             context=view_result.context,
-            execution_time=time.time() - start_time,
+            execution_time=time.monotonic() - start_time,
             execution_time_view=end_time_view - start_time_view,
             view_name=selected_view,
             textual_response=textual_response,


### PR DESCRIPTION
This PR replaces `time.time()` calls with `time.monotonic()` for more reliable benchmarking.