### PR TITLE
docs: add about section to documentation

### DIFF
--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -1,0 +1,2 @@
+
+--8<-- "CHANGELOG.md"

--- a/docs/about/contact.md
+++ b/docs/about/contact.md
@@ -1,0 +1,8 @@
+# Contact us
+
+Hey 👋 My name is Mateusz, and I'm a lead maintainer of db-ally.
+
+
+
+You can contact me directly at [db-ally@deepsense.ai](mailto:db-ally@deepsense.ai)
+

--- a/docs/about/contributing.md
+++ b/docs/about/contributing.md
@@ -1,0 +1,64 @@
+# Contributing
+
+We are happy to see you here! 🚀
+
+Looking for a way to contribute to db-ally? Check-out our issues with a [good first issue](https://github.com/deepsense-ai/db-ally/labels/good%20first%20issue) label.
+
+You can also suggest new features or report bugs by [opening an issue](https://github.com/deepsense-ai/db-ally/issues).
+
+## Contributor guide
+
+1. Fork the repository and clone it locally.
+
+2. Install the development dependencies:
+
+    ```bash
+    ./setup_dev_env.sh
+    ```
+
+    It will create a virtual environment and install all necessary dependencies.
+    Make sure that you have Python 3.8 or higher installed on your machine.
+
+3. Make your changes and write tests for them if necessary.
+
+4. Run the tests:
+
+    ```bash
+    pytest tests/
+    ```
+
+5. If creating new feature, don't forget to update the documentation.
+
+    You can run the documentation locally by executing:
+
+    ```bash
+    mkdocs serve
+    ```
+
+6. Push your changes to your fork and create a pull request from there.
+
+
+## Commits convention
+
+We use [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for our commit messages.
+
+In practice that means that each commit message should be prefixed with one of the following types:
+
+```
+feat:     A new feature
+fix:      A bug fix
+docs:     Documentation only changes
+refactor: A code change that neither fixes a bug nor adds a feature
+test:     Adding missing tests or correcting existing tests
+chore:    Changes to the build process or repo setup
+```
+
+For example:
+```
+feat: add text2sql views code generation
+```
+
+Breaking changes should be indicated by adding an exclamation mark to the prefix:
+```
+feat!: change collection.ask method API
+```

--- a/docs/about/roadmap.md
+++ b/docs/about/roadmap.md
@@ -1,8 +1,3 @@
----
-hide:
-  - navigation
----
-
 # Roadmap
 
 db-ally is actively developed and maintained by a core team at [deepsense.ai](https://deepsense.ai) and a community of contributors.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -73,8 +73,11 @@ nav:
       - Embeddings:
           - reference/embeddings/index.md
           - reference/embeddings/litellm.md
-  - Roadmap: roadmap.md
-
+  - About:
+    - about/roadmap.md
+    - about/contributing.md
+    - about/changelog.md
+    - about/contact.md
 theme:
   name: material
   icon:


### PR DESCRIPTION
This PR adds `about` section to documentation with pages:

* Roadmap
* Contributing
* Changelog
* Contact us