### PR TITLE
refactor(iql): errors definition

### DIFF
--- a/src/dbally/iql/_exceptions.py
+++ b/src/dbally/iql/_exceptions.py
@@ -1,5 +1,5 @@
 import ast
-from typing import List, Optional, Union
+from typing import List, Optional
 
 from dbally.exceptions import DbAllyError
 
@@ -31,7 +31,7 @@ class IQLEmptyExpressionError(IQLError):
 class IQLMultipleExpressionsError(IQLError):
     """Raised when IQL contains multiple expressions."""
 
-    def __init__(self, nodes: List[Union[ast.stmt, ast.expr]], source: str) -> None:
+    def __init__(self, nodes: List[ast.stmt], source: str) -> None:
         message = "Multiple expressions or statements in IQL are not supported"
         super().__init__(message, source)
         self.nodes = nodes
@@ -41,7 +41,7 @@ class IQLExpressionError(IQLError):
     """Raised when IQL expression is invalid."""
 
     def __init__(self, message: str, node: ast.expr, source: str) -> None:
-        message = message + ": " + source[node.col_offset : node.end_col_offset]
+        message = f"{message}: {source[node.col_offset : node.end_col_offset]}"
         super().__init__(message, source)
         self.node = node
 
@@ -84,7 +84,7 @@ class IQLFunctionNotExists(IQLExpressionError):
         super().__init__(message, node, source)
 
 
-class IQLIcorrectNumberArgumentsError(IQLExpressionError):
+class IQLIncorrectNumberArgumentsError(IQLExpressionError):
     """Raised when IQL contains too many arguments for a function."""
 
     def __init__(self, node: ast.Call, source: str) -> None:

--- a/src/dbally/iql/_processor.py
+++ b/src/dbally/iql/_processor.py
@@ -8,7 +8,7 @@ from dbally.iql._exceptions import (
     IQLArgumentValidationError,
     IQLEmptyExpressionError,
     IQLFunctionNotExists,
-    IQLIcorrectNumberArgumentsError,
+    IQLIncorrectNumberArgumentsError,
     IQLMultipleExpressionsError,
     IQLNoExpressionError,
     IQLSyntaxError,
@@ -93,7 +93,7 @@ class IQLProcessor:
         args = []
 
         if len(func_def.parameters) != len(node.args):
-            raise IQLIcorrectNumberArgumentsError(node, self.source)
+            raise IQLIncorrectNumberArgumentsError(node, self.source)
 
         for arg, arg_def in zip(node.args, func_def.parameters):
             arg_value = self._parse_arg(arg)

--- a/src/dbally/iql/_query.py
+++ b/src/dbally/iql/_query.py
@@ -33,11 +33,15 @@ class IQLQuery:
         Parse IQL string to IQLQuery object.
 
         Args:
-            source: IQL string that needs to be parsed
-            allowed_functions: list of IQL functions that are allowed for this query
-            event_tracker: EventTracker object to track events
+            source: IQL string that needs to be parsed.
+            allowed_functions: List of IQL functions that are allowed for this query.
+            event_tracker: EventTracker object to track events.
+
         Returns:
-             IQLQuery object
+            IQLQuery object.
+
+        Raises:
+            IQLError: If parsing fails.
         """
         root = await IQLProcessor(source, allowed_functions, event_tracker=event_tracker).process()
         return cls(root=root, source=source)

--- a/src/dbally/views/structured.py
+++ b/src/dbally/views/structured.py
@@ -55,6 +55,9 @@ class BaseStructuredView(BaseView):
 
         Returns:
             The result of the query.
+
+        Raises:
+            IQLError: If the generated IQL query is not valid.
         """
         iql_generator = self.get_iql_generator(llm)
 

--- a/tests/integration/test_llm_options.py
+++ b/tests/integration/test_llm_options.py
@@ -1,4 +1,4 @@
-from unittest.mock import ANY, AsyncMock, call
+from unittest.mock import ANY, AsyncMock, call, patch
 
 import pytest
 
@@ -24,11 +24,12 @@ async def test_llm_options_propagation():
     collection.add(MockView1)
     collection.add(MockView2)
 
-    await collection.ask(
-        question="Mock question",
-        return_natural_response=True,
-        llm_options=custom_options,
-    )
+    with patch("dbally.iql.IQLQuery.parse", AsyncMock()):
+        await collection.ask(
+            question="Mock question",
+            return_natural_response=True,
+            llm_options=custom_options,
+        )
 
     assert llm.client.call.call_count == 3
 

--- a/tests/unit/iql/test_iql_parser.py
+++ b/tests/unit/iql/test_iql_parser.py
@@ -8,7 +8,7 @@ from dbally.iql._exceptions import (
     IQLArgumentValidationError,
     IQLEmptyExpressionError,
     IQLFunctionNotExists,
-    IQLIcorrectNumberArgumentsError,
+    IQLIncorrectNumberArgumentsError,
     IQLMultipleExpressionsError,
     IQLNoExpressionError,
     IQLSyntaxError,
@@ -185,7 +185,7 @@ async def test_iql_parser_method_not_exists():
 
 
 async def test_iql_parser_incorrect_number_of_arguments_fail():
-    with pytest.raises(IQLIcorrectNumberArgumentsError) as exc_info:
+    with pytest.raises(IQLIncorrectNumberArgumentsError) as exc_info:
         await IQLQuery.parse(
             "filter_by_age('too old', 40)",
             allowed_functions=[

--- a/tests/unit/iql/test_iql_parser.py
+++ b/tests/unit/iql/test_iql_parser.py
@@ -4,7 +4,15 @@ from typing import List
 import pytest
 
 from dbally.iql import IQLArgumentParsingError, IQLQuery, IQLUnsupportedSyntaxError, syntax
-from dbally.iql._exceptions import IQLArgumentValidationError, IQLFunctionNotExists
+from dbally.iql._exceptions import (
+    IQLArgumentValidationError,
+    IQLEmptyExpressionError,
+    IQLFunctionNotExists,
+    IQLIcorrectNumberArgumentsError,
+    IQLMultipleExpressionsError,
+    IQLNoExpressionError,
+    IQLSyntaxError,
+)
 from dbally.iql._processor import IQLProcessor
 from dbally.views.exposed_functions import ExposedFunction, MethodParamWithTyping
 
@@ -68,6 +76,78 @@ async def test_iql_parser_arg_error():
     assert exc_info.match(re.escape("Not a valid IQL argument: lambda x: x + 1"))
 
 
+async def test_iql_parser_syntax_error():
+    with pytest.raises(IQLSyntaxError) as exc_info:
+        await IQLQuery.parse(
+            "filter_by_age(",
+            allowed_functions=[
+                ExposedFunction(
+                    name="filter_by_age",
+                    description="",
+                    parameters=[
+                        MethodParamWithTyping(name="age", type=int),
+                    ],
+                ),
+            ],
+        )
+
+    assert exc_info.match(re.escape("Syntax error in: filter_by_age("))
+
+
+async def test_iql_parser_multiple_expression_error():
+    with pytest.raises(IQLMultipleExpressionsError) as exc_info:
+        await IQLQuery.parse(
+            "filter_by_age\nfilter_by_age",
+            allowed_functions=[
+                ExposedFunction(
+                    name="filter_by_age",
+                    description="",
+                    parameters=[
+                        MethodParamWithTyping(name="age", type=int),
+                    ],
+                ),
+            ],
+        )
+
+    assert exc_info.match(re.escape("Multiple expressions or statements in IQL are not supported"))
+
+
+async def test_iql_parser_empty_expression_error():
+    with pytest.raises(IQLEmptyExpressionError) as exc_info:
+        await IQLQuery.parse(
+            "",
+            allowed_functions=[
+                ExposedFunction(
+                    name="filter_by_age",
+                    description="",
+                    parameters=[
+                        MethodParamWithTyping(name="age", type=int),
+                    ],
+                ),
+            ],
+        )
+
+    assert exc_info.match(re.escape("Empty IQL expression"))
+
+
+async def test_iql_parser_no_expression_error():
+    with pytest.raises(IQLNoExpressionError) as exc_info:
+        await IQLQuery.parse(
+            "import filter_by_age",
+            allowed_functions=[
+                ExposedFunction(
+                    name="filter_by_age",
+                    description="",
+                    parameters=[
+                        MethodParamWithTyping(name="age", type=int),
+                    ],
+                ),
+            ],
+        )
+
+    assert exc_info.match(re.escape("No expression found in IQL: import filter_by_age"))
+
+
 async def test_iql_parser_unsupported_syntax_error():
     with pytest.raises(IQLUnsupportedSyntaxError) as exc_info:
         await IQLQuery.parse(
@@ -102,6 +182,26 @@ async def test_iql_parser_method_not_exists():
         )
 
     assert exc_info.match(re.escape("Function filter_by_how_old_somebody_is not exists: filter_by_how_old_somebody_is"))
+
+
+async def test_iql_parser_incorrect_number_of_arguments_fail():
+    with pytest.raises(IQLIcorrectNumberArgumentsError) as exc_info:
+        await IQLQuery.parse(
+            "filter_by_age('too old', 40)",
+            allowed_functions=[
+                ExposedFunction(
+                    name="filter_by_age",
+                    description="",
+                    parameters=[
+                        MethodParamWithTyping(name="age", type=int),
+                    ],
+                ),
+            ],
+        )
+
+    assert exc_info.match(
+        re.escape("The method filter_by_age has incorrect number of arguments: filter_by_age('too old', 40)")
+    )
 
 
 async def test_iql_parser_argument_validation_fail():

--- a/tests/unit/test_iql_generator.py
+++ b/tests/unit/test_iql_generator.py
@@ -84,7 +84,7 @@ async def test_iql_generation(iql_generator: IQLGenerator, event_tracker: EventT
 
 
 @pytest.mark.asyncio
-async def test_iql_generation_error_excalation_after_max_retires(
+async def test_iql_generation_error_escalation_after_max_retires(
     iql_generator: IQLGenerator,
     event_tracker: EventTracker,
     view: MockView,


### PR DESCRIPTION
This PR adds 5 new errors raised during ast parsing + removed legacy `ValueError` from `IQLProcessor`. Also added some new tests for IQL parsing and the IQL generator's retry flow.